### PR TITLE
do not allow entering empty todos

### DIFF
--- a/cypress/integration/02-adding-items/answer.js
+++ b/cypress/integration/02-adding-items/answer.js
@@ -1,4 +1,8 @@
 /// <reference types="cypress" />
+// IMPORTANT ⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️
+// remember to manually delete all items before running the test
+// IMPORTANT ⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️
+
 beforeEach(() => {
   cy.visit('localhost:3000')
 })
@@ -80,6 +84,19 @@ it('adds item with random text', () => {
 
 it('starts with zero items', () => {
   cy.get('li.todo').should('have.length', 0)
+})
+
+it('does not allow adding blank todos', () => {
+  cy.on('uncaught:exception', e => {
+    // what will happen if this assertion fails?
+    // will the test fail?
+    // expect(e.message).to.include('Cannot add a blank todo')
+    // return false
+
+    // a better shortcut
+    return !e.message.includes('Cannot add a blank todo')
+  })
+  addItem(' ')
 })
 
 // what a challenge?

--- a/cypress/integration/02-adding-items/spec.js
+++ b/cypress/integration/02-adding-items/spec.js
@@ -5,7 +5,9 @@ it('loads', () => {
   cy.contains('h1', 'todos')
 })
 
+// IMPORTANT ⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️
 // remember to manually delete all items before running the test
+// IMPORTANT ⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️
 
 it('adds two items', () => {
   // repeat twice
@@ -53,6 +55,16 @@ it('starts with zero items', () => {
   //   in the list
   //   use cy.get(...) and it should have length of 0
   //   https://on.cypress.io/get
+})
+
+it('does not allow adding blank todos', () => {
+  // https://on.cypress.io/catalog-of-events#App-Events
+  cy.on('uncaught:exception', () => {
+    // check e.message to match expected error text
+    // return false if you want to ignore the error
+  })
+
+  // try adding an item with just spaces
 })
 
 // what a challenge?

--- a/cypress/integration/05-xhr/answer.js
+++ b/cypress/integration/05-xhr/answer.js
@@ -145,3 +145,22 @@ it('shows loading element', () => {
   // now the Loading element should go away
   cy.get('.loading').should('not.be.visible')
 })
+
+it('handles todos with blank title', () => {
+  cy.server()
+  cy.route('/todos', [
+    {
+      id: '123',
+      title: '  ',
+      completed: false
+    }
+  ])
+
+  cy.visit('/')
+  cy.get('li.todo')
+    .should('have.length', 1)
+    .first()
+    .should('not.have.class', 'completed')
+    .find('label')
+    .should('have.text', '  ')
+})

--- a/cypress/integration/05-xhr/spec.js
+++ b/cypress/integration/05-xhr/spec.js
@@ -100,3 +100,9 @@ it('shows loading element', () => {
   // wait for the network call to complete
   // now the Loading element should go away
 })
+
+it('handles todos with blank title', () => {
+  // return a list of todos with one todo object
+  // having blank spaces or null
+  // confirm the todo item is shown correctly
+})

--- a/cypress/integration/06-app-data-store/answer.js
+++ b/cypress/integration/06-app-data-store/answer.js
@@ -62,3 +62,43 @@ it('puts todos in the store', () => {
       { title: 'else', completed: false, id: '2' }
     ])
 })
+
+it('adds todos via app', () => {
+  // bypass the UI and call app's actions directly from the test
+  // app.$store.dispatch('setNewTodo', <desired text>)
+  // app.$store.dispatch('addTodo')
+  // using https://on.cypress.io/invoke
+  // bypass the UI and call app's actions directly from the test
+  // app.$store.dispatch('setNewTodo', <desired text>)
+  // app.$store.dispatch('addTodo')
+  cy.window()
+    .its('app.$store')
+    .invoke('dispatch', 'setNewTodo', 'new todo')
+
+  cy.window()
+    .its('app.$store')
+    .invoke('dispatch', 'addTodo')
+  // and then check the UI
+  cy.contains('li.todo', 'new todo')
+})
+
+it('handles todos with blank title', () => {
+  // bypass the UI and call app's actions directly from the test
+  // app.$store.dispatch('setNewTodo', <desired text>)
+  // app.$store.dispatch('addTodo')
+  cy.window()
+    .its('app.$store')
+    .invoke('dispatch', 'setNewTodo', '  ')
+
+  cy.window()
+    .its('app.$store')
+    .invoke('dispatch', 'addTodo')
+
+  // confirm the application is not breaking
+  cy.get('li.todo')
+    .should('have.length', 1)
+    .first()
+    .should('not.have.class', 'completed')
+    .find('label')
+    .should('have.text', '  ')
+})

--- a/cypress/integration/06-app-data-store/spec.js
+++ b/cypress/integration/06-app-data-store/spec.js
@@ -62,3 +62,12 @@ it('puts the todo items into the data store', () => {
   // get the data store
   // check its contents
 })
+
+it('handles todos with blank title', () => {
+  // bypass the UI and call app's actions directly from the test
+  // app.$store.dispatch('setNewTodo', <desired text>)
+  // app.$store.dispatch('addTodo')
+  // using https://on.cypress.io/invoke
+  // and then
+  // confirm the application is not breaking
+})

--- a/slides/02-adding-items/PITCHME.md
+++ b/slides/02-adding-items/PITCHME.md
@@ -121,7 +121,15 @@ it('adds item with random text', () => {
 - set up IntelliSense in `cypress.json` using [https://on.cypress.io/intelligent-code-completion](https://on.cypress.io/intelligent-code-completion)
 
 +++
+## Adding blank item
 
+The application does not allow adding items with blank titles. What happens when the user does it? Hint: open DevTools console.
+
+### Todo
+
+Fill the test `does not allow adding blank todos`.
+
++++
 ## Bonus
 
 Unit tests vs end-to-end tests

--- a/slides/02-adding-items/PITCHME.md
+++ b/slides/02-adding-items/PITCHME.md
@@ -219,3 +219,9 @@ describe('Feature A', () => {
   })
 })
 ```
+
++++
+## 🏁 Write your tests like a user
+
+- go through UI
+- validate the application after actions

--- a/slides/05-xhr/PITCHME.md
+++ b/slides/05-xhr/PITCHME.md
@@ -208,3 +208,16 @@ In the application we are showing (very quickly) "Loading" state
 - assert the "Loading" element goes away after XHR completes
 
 ⌨️ test "shows loading element"
+
++++
+## Let's test edge data cases
+
+User cannot enter blank titles. What if our database has old data records with blank titles?
+
+**Todo** write the test `handles todos with blank title`
+
++++
+## 🏁 Spy and stub the network from your tests
+
+- confirm the REST calls
+- stub random data

--- a/slides/06-app-data-store/PITCHME.md
+++ b/slides/06-app-data-store/PITCHME.md
@@ -119,6 +119,36 @@ Write a test that:
 - dispatches actions to the store to add items
 - confirms new items are added to the DOM
 
+(see next slide)
++++
+
+```js
+it('adds todos via app', () => {
+  // bypass the UI and call app's actions directly from the test
+  // app.$store.dispatch('setNewTodo', <desired text>)
+  // app.$store.dispatch('addTodo')
+  // using https://on.cypress.io/invoke
+  // bypass the UI and call app's actions directly from the test
+  // app.$store.dispatch('setNewTodo', <desired text>)
+  // app.$store.dispatch('addTodo')
+  // and then check the UI
+})
+```
+
++++
+## Todo: test edge data case
+
+```js
+it('handles todos with blank title', () => {
+  // add todo that the user cannot add via UI
+  cy.window()
+    .its('app.$store')
+    .invoke('dispatch', 'setNewTodo', '  ')
+  // app.$store.dispatch('addTodo')
+  // confirm the UI
+})
+```
+
 +++
 
 ### ⚠️ Watch out for stale data
@@ -152,3 +182,10 @@ getStore()
   .should('have.length', 1)
 // do other checks
 ```
+
++++
+## 🏁 App Access
+
+- when needed, you can access the application directly from the test
+
+Read also: https://www.cypress.io/blog/2018/11/14/testing-redux-store/

--- a/todomvc/app.js
+++ b/todomvc/app.js
@@ -1,5 +1,6 @@
 /* global Vue, Vuex, axios */
 /* eslint-disable no-console */
+/* eslint-disable-next-line */
 ; (function () {
   Vue.use(Vuex)
 
@@ -156,7 +157,7 @@
       addTodo(e) {
         // do not allow adding empty todos
         if (!e.target.value.trim()) {
-          return
+          throw new Error('Cannot add a blank todo')
         }
         e.target.value = ''
         this.$store.dispatch('addTodo')

--- a/todomvc/app.js
+++ b/todomvc/app.js
@@ -1,9 +1,9 @@
-/* global Vue, Vuex, axios, FileReader, window, Promise */
+/* global Vue, Vuex, axios */
 /* eslint-disable no-console */
-;(function () {
+; (function () {
   Vue.use(Vuex)
 
-  function randomId () {
+  function randomId() {
     return Math.random()
       .toString()
       .substr(2, 10)
@@ -21,30 +21,30 @@
       loading: state => state.loading
     },
     mutations: {
-      SET_LOADING (state, flag) {
+      SET_LOADING(state, flag) {
         state.loading = flag
       },
-      SET_TODOS (state, todos) {
+      SET_TODOS(state, todos) {
         state.todos = todos
       },
-      SET_NEW_TODO (state, todo) {
+      SET_NEW_TODO(state, todo) {
         state.newTodo = todo
       },
-      ADD_TODO (state, todoObject) {
+      ADD_TODO(state, todoObject) {
         console.log('add todo', todoObject)
         state.todos.push(todoObject)
       },
-      REMOVE_TODO (state, todo) {
+      REMOVE_TODO(state, todo) {
         let todos = state.todos
         todos.splice(todos.indexOf(todo), 1)
       },
-      CLEAR_NEW_TODO (state) {
+      CLEAR_NEW_TODO(state) {
         state.newTodo = ''
         console.log('clearing new todo')
       }
     },
     actions: {
-      loadTodos ({ commit }) {
+      loadTodos({ commit }) {
         commit('SET_LOADING', true)
 
         axios
@@ -68,10 +68,10 @@
        * @param {any} { commit }
        * @param {string} todo Message
        */
-      setNewTodo ({ commit }, todo) {
+      setNewTodo({ commit }, todo) {
         commit('SET_NEW_TODO', todo)
       },
-      addTodo ({ commit, state }) {
+      addTodo({ commit, state }) {
         if (!state.newTodo) {
           // do not add empty todos
           return
@@ -85,8 +85,7 @@
           commit('ADD_TODO', todo)
         })
       },
-      addEntireTodo ({ commit }, todoFields) {
-        debugger
+      addEntireTodo({ commit }, todoFields) {
         const todo = {
           ...todoFields,
           id: randomId()
@@ -95,17 +94,17 @@
           commit('ADD_TODO', todo)
         })
       },
-      removeTodo ({ commit }, todo) {
+      removeTodo({ commit }, todo) {
         axios.delete(`/todos/${todo.id}`).then(() => {
           console.log('removed todo', todo.id, 'from the server')
           commit('REMOVE_TODO', todo)
         })
       },
-      clearNewTodo ({ commit }) {
+      clearNewTodo({ commit }) {
         commit('CLEAR_NEW_TODO')
       },
       // example promise-returning action
-      addTodoAfterDelay ({ commit }, { milliseconds, title }) {
+      addTodoAfterDelay({ commit }, { milliseconds, title }) {
         return new Promise(resolve => {
           setTimeout(() => {
             const todo = {
@@ -129,20 +128,20 @@
     },
     el: '.todoapp',
 
-    created () {
+    created() {
       this.$store.dispatch('loadTodos')
     },
 
     // computed properties
     // https://vuejs.org/guide/computed.html
     computed: {
-      loading () {
+      loading() {
         return this.$store.getters.loading
       },
-      newTodo () {
+      newTodo() {
         return this.$store.getters.newTodo
       },
-      todos () {
+      todos() {
         return this.$store.getters.todos
       }
     },
@@ -150,22 +149,26 @@
     // methods that implement data logic.
     // note there's no DOM manipulation here at all.
     methods: {
-      setNewTodo (e) {
+      setNewTodo(e) {
         this.$store.dispatch('setNewTodo', e.target.value)
       },
 
-      addTodo (e) {
+      addTodo(e) {
+        // do not allow adding empty todos
+        if (!e.target.value.trim()) {
+          return
+        }
         e.target.value = ''
         this.$store.dispatch('addTodo')
         this.$store.dispatch('clearNewTodo')
       },
 
-      removeTodo (todo) {
+      removeTodo(todo) {
         this.$store.dispatch('removeTodo', todo)
       },
 
       // utility method for create a todo with title and completed state
-      addEntireTodo (title, completed = false) {
+      addEntireTodo(title, completed = false) {
         this.$store.dispatch('addEntireTodo', { title, completed })
       }
     }


### PR DESCRIPTION
- closes #206 
- UI does not allow adding empty todos
- [x] add a test and a slide to test that the user cannot add an empty todo
- [x] show how to test the app with empty todos via Network Stubbing 
- [x] show how to test the app with empty todos via App Actions